### PR TITLE
Add notifications settings change feedback

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2135,3 +2135,34 @@ span#profileFullname{
 .tb-no-icon .title-text {
     line-height : 2.2;
 }
+.alert-notify-success {
+    padding: 5px;
+    color: #3C763D;
+}
+.alert-notify-danger {
+    padding: 5px;
+    color: #A94442;
+}
+.notifications-loading {
+    text-align: center;
+    font-size: 16px;
+    font-weight: 200;
+    padding: 20px;
+}
+.notifications-spin {
+    -webkit-animation: spin 2s infinite linear;
+    animation: spin 2s infinite linear;
+}
+
+@-moz-keyframes spin {
+    from { -moz-transform: rotate(0deg); }
+    to { -moz-transform: rotate(360deg); }
+}
+@-webkit-keyframes spin {
+    from { -webkit-transform: rotate(0deg); }
+    to { -webkit-transform: rotate(360deg); }
+}
+@keyframes spin {
+    from {transform:rotate(0deg);}
+    to {transform:rotate(360deg);}
+}

--- a/website/static/js/project-settings-treebeard.js
+++ b/website/static/js/project-settings-treebeard.js
@@ -66,7 +66,9 @@ function openAncestors (tb, item) {
     }
 }
 
-function subscribe(id, event, notification_type) {
+function subscribe(item, notification_type) {
+    var id = item.parent().data.node.id; 
+    var event = item.data.event.title
     var payload = {
         'id': id,
         'event': event,
@@ -75,8 +77,11 @@ function subscribe(id, event, notification_type) {
     $osf.postJSON(
         '/api/v1/subscriptions/',
         payload
-    ).fail(function() {
-        bootbox.alert('Could not update notification preferences.');
+    ).done(function(){
+        item.notify.update('Settings updated', 'notify-success', 1, 2000);
+        item.data.event.notificationType = notification_type;
+    }).fail(function() {
+        item.notify.update('Could not update settings', 'notify-danger', 1, 2000);
     });
 }
 
@@ -188,7 +193,6 @@ function ProjectNotifications(data) {
                     sortInclude : false,
                     custom : function(item, col) {
                         return item.data.event.description;
-
                     }
                 },
                 {
@@ -199,8 +203,7 @@ function ProjectNotifications(data) {
                         return m("div[style='padding-right:10px']",
                             [m('select.form-control', {
                                 onchange: function(ev) {
-                                    item.data.event.notificationType = ev.target.value;
-                                    subscribe(item.parent().data.node.id, item.data.event.title, item.data.event.notificationType)
+                                    subscribe(item, ev.target.value);
                                 }},
                                 [
                                     m('option', {value: 'none', selected : item.data.event.notificationType === 'none' ? 'selected': ''}, 'None'),
@@ -232,8 +235,7 @@ function ProjectNotifications(data) {
                         return  m("div[style='padding-right:10px']",
                             [m('select.form-control', {
                                 onchange: function(ev) {
-                                    item.data.event.notificationType = ev.target.value;
-                                    subscribe(item.parent().data.node.id, item.data.event.title, item.data.event.notificationType)
+                                    subscribe(item, ev.target.value);
                                 }},
                                 [
                                     m('option', {value: 'adopt_parent',

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -49,7 +49,9 @@
         <div class="panel panel-default">
             <div class="panel-heading"><h3 class="panel-title">Configure Notification Preferences</h3></div>
                 <form id="selectNotifications" class="osf-treebeard-minimal">
-                    <div id="grid"></div>
+                    <div id="grid">
+                            <div class="notifications-loading"> <i class="icon-spinner notifications-spin"></i> <p class="m-t-sm fg-load-message"> Loading notification settings...  </p> </div>
+                    </div>
                     <div class="help-block" style="padding-left: 15px">
                             <p id="configureNotificationsMessage"></p>
                     </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -107,7 +107,9 @@
                 </div>
 
                 <form id="notificationSettings" class="osf-treebeard-minimal">
-                    <div id="grid"></div>
+                    <div id="grid">
+    <div class="notifications-loading"> <i class="icon-spinner notifications-spin"></i> <p class="m-t-sm fg-load-message"> Loading notification settings...  </p> </div>
+                    </div>
                     <div class="help-block" style="padding-left: 15px">
                             <p id="configureNotificationsMessage"></p>
                     </div>


### PR DESCRIPTION
## Purpose

Add feedback to notification settings when user changes a setting and add loading text
## Changes
- Made changes in the subscribe function that runs onchange for the select in row 2 so the arguments are optimized
- The change to the notification shows text in green or red based on result of server call
- The notification select returns to changed or original position based on result of the server call
- CSS added to site.css for making notification specific feedback work
- Bootbox is removed
## Side effects

None. Bootbox might not be necessary to load anymore. 
