### PR TITLE
Add event condition to scrolling so it does not happen on click to open ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "raw-loader": "^0.5.1",
     "share": "~0.7.3",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#afec93f9c7a06b61b36fc443c531486fed48150f",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#d6e486b5dcfb3efd062758c1ec7c92735203e5d7",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -142,13 +142,15 @@ function _resolveLazyLoad(item) {
     return waterbutler.buildTreeBeardMetadata(item, {ref: item.data.branch});
 }
 
-function _fangornLazyLoadOnLoad (tree) {
+function _fangornLazyLoadOnLoad (tree, event) {
     var tb = this;
     tree.children.forEach(function(item) {
         Fangorn.Utils.inheritFromParent(item, tree, ['branch']);
     });
     Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
-    Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
+    if(!event){
+        Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
+    }
 }
 
 function _fangornGithubTitle(item, col)  {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -588,11 +588,11 @@ function reapplyTooltips () {
  * @this Treebeard.controller
  * @private
  */
-function _fangornLazyLoadOnLoad (tree) {
+function _fangornLazyLoadOnLoad (tree, event) {
     tree.children.forEach(function(item) {
         inheritFromParent(item, tree);
     });
-    resolveconfigOption.call(this, tree, 'lazyLoadOnLoad', [tree]);
+    resolveconfigOption.call(this, tree, 'lazyLoadOnLoad', [tree, event]);
     reapplyTooltips();
 
     if (tree.depth > 1) {

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -63,11 +63,14 @@ function FileViewTreebeard(data) {
             this.options.showTotal = Math.floor(containerHeight / this.options.rowHeight) + 1;
             this.redraw();
         },
-        lazyLoadOnLoad: function(tree) {
+        lazyLoadOnLoad: function(tree, event) {
+            console.log(tree, event);
             var tb = this;
             Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree);
             Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
-            Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
+            if(!event) { 
+                Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
+            }
         },
         resolveRows: function (item) {
             var selectClass = '';

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -64,7 +64,6 @@ function FileViewTreebeard(data) {
             this.redraw();
         },
         lazyLoadOnLoad: function(tree, event) {
-            console.log(tree, event);
             var tb = this;
             Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree);
             Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -65,7 +65,7 @@ function FileViewTreebeard(data) {
         },
         lazyLoadOnLoad: function(tree, event) {
             var tb = this;
-            Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree);
+            Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree, event);
             Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
             if(!event) { 
                 Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);


### PR DESCRIPTION
...folder
## Purpose

Uses the newly added event argument in lazyloadonload so that scrolltoFile does NOT happen if event exists. 

Event argument will exist if an actual click is done.  
